### PR TITLE
Feat: 게시글 작성 시 로그인 회원 인증 추가

### DIFF
--- a/src/main/java/com/example/gasip/board/controller/BoardController.java
+++ b/src/main/java/com/example/gasip/board/controller/BoardController.java
@@ -2,10 +2,12 @@ package com.example.gasip.board.controller;
 
 import com.example.gasip.board.dto.*;
 import com.example.gasip.board.service.BoardService;
+import com.example.gasip.global.security.MemberDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,10 +17,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BoardController {
     private final BoardService boardService;
-    @PostMapping("")
+    @PostMapping("{profId}")
     @Operation(summary = "게시글 생성 요청", description = "게시글을 생성을 요청합니다.", tags = { "Board Controller" })
-    public ResponseEntity<BoardCreateResponse> createBoard(@RequestBody @Valid BoardCreateRequest boardCreateRequest) {
-        return ResponseEntity.ok(boardService.createBoard(boardCreateRequest));
+    public ResponseEntity<BoardCreateResponse> createBoard(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @RequestBody @Valid BoardCreateRequest boardCreateRequest,
+        @PathVariable Long profId) {
+        return ResponseEntity.ok(boardService.createBoard(boardCreateRequest,memberDetails,profId));
     }
 
     @GetMapping("")

--- a/src/main/java/com/example/gasip/board/dto/BoardCreateRequest.java
+++ b/src/main/java/com/example/gasip/board/dto/BoardCreateRequest.java
@@ -2,6 +2,7 @@ package com.example.gasip.board.dto;
 
 import com.example.gasip.global.entity.BaseTimeEntity;
 import com.example.gasip.board.model.Board;
+import com.example.gasip.member.model.Member;
 import com.example.gasip.professor.model.Professor;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -22,17 +23,19 @@ public class BoardCreateRequest extends BaseTimeEntity {
     private Long clickCount;
     @Schema(description = "게시글 좋아요")
     private Long likeCount;
-//    @NotNull
-@Schema(description = "게시글과 관련된 교수 정보")
+    @Schema(description = "게시글과 관련된 교수 정보")
     private Professor professor;
+    @Schema(description = "게시글 작성한 사용자")
+    private Member member;
 
 
-    public Board toEntity(BoardCreateRequest boardCreateRequest) {
+    public Board toEntity(Professor prof, Member mem) {
         return Board.builder()
-                .content(boardCreateRequest.getContent())
-                .clickCount(boardCreateRequest.getClickCount())
-                .likeCount(boardCreateRequest.getLikeCount())
-                .professor(boardCreateRequest.getProfessor())
+                .content(content)
+                .clickCount(clickCount)
+                .likeCount(likeCount)
+                .professor(prof)
+                .member(mem)
                 .build();
     }
 

--- a/src/main/java/com/example/gasip/board/dto/BoardCreateResponse.java
+++ b/src/main/java/com/example/gasip/board/dto/BoardCreateResponse.java
@@ -28,15 +28,15 @@ public class BoardCreateResponse extends BaseTimeEntity {
     private Long likeCount;
     @NotNull
     @Schema(description = "게시글과 관련된 교수 정보")
-    private Professor professor;
+    private Long profId;
 
-    public BoardCreateResponse(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Long clickCount, Long likeCount, Professor professor) {
+    public BoardCreateResponse(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Professor professor) {
         super(regDate, updateDate);
         this.postId = postId;
         this.content = content;
-        this.clickCount = clickCount;
-        this.likeCount = likeCount;
-        this.professor = professor;
+        this.clickCount = 0L;
+        this.likeCount = 0L;
+        this.profId = professor.getProfId();
     }
 
     //fromEntity메서드 개발
@@ -46,9 +46,9 @@ public class BoardCreateResponse extends BaseTimeEntity {
                 .updateDate(board.getUpdateDate())
                 .postId(board.getPostId())
                 .content(board.getContent())
-                .clickCount(board.getClickCount())
-                .likeCount(board.getLikeCount())
-                .professor(board.getProfessor())
+                .clickCount(0L)
+                .likeCount(0L)
+                .profId(board.getProfessor().getProfId())
                 .build();
     }
 

--- a/src/main/java/com/example/gasip/board/service/BoardService.java
+++ b/src/main/java/com/example/gasip/board/service/BoardService.java
@@ -3,6 +3,11 @@ package com.example.gasip.board.service;
 import com.example.gasip.board.dto.*;
 import com.example.gasip.board.model.Board;
 import com.example.gasip.board.repository.BoardRepository;
+import com.example.gasip.global.security.MemberDetails;
+import com.example.gasip.member.model.Member;
+import com.example.gasip.member.repository.MemberRepository;
+import com.example.gasip.professor.model.Professor;
+import com.example.gasip.professor.repository.ProfessorRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,10 +21,14 @@ import java.util.List;
 public class BoardService {
 
     private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
+    private final ProfessorRepository professorRepository;
 
     @Transactional
-    public BoardCreateResponse createBoard(BoardCreateRequest boardCreateRequest) {
-        Board board = boardRepository.save(boardCreateRequest.toEntity(boardCreateRequest));
+    public BoardCreateResponse createBoard(BoardCreateRequest boardCreateRequest, MemberDetails memberDetails, Long profId) {
+        Member member = memberRepository.getReferenceById(memberDetails.getId());
+        Professor professor = professorRepository.findById(profId).orElseThrow(IllegalArgumentException::new);
+        Board board = boardRepository.save(boardCreateRequest.toEntity(professor,member));
         return BoardCreateResponse.fromEntity(board);
     }
 

--- a/src/main/java/com/example/gasip/college/model/College.java
+++ b/src/main/java/com/example/gasip/college/model/College.java
@@ -1,6 +1,5 @@
 package com.example.gasip.college.model;
 
-import com.example.gasip.global.entity.BaseTimeEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -8,7 +7,7 @@ import lombok.Getter;
 @Entity
 @Getter
 @Schema(description = "단과대 관련 VO")
-public class College extends BaseTimeEntity {
+public class College {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Schema(description = "단과대 ID")

--- a/src/main/java/com/example/gasip/member/dto/MemberMyPageRequest.java
+++ b/src/main/java/com/example/gasip/member/dto/MemberMyPageRequest.java
@@ -1,9 +1,0 @@
-package com.example.gasip.member.dto;
-
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-public class MemberMyPageRequest {
-}

--- a/src/main/java/com/example/gasip/member/service/MemberService.java
+++ b/src/main/java/com/example/gasip/member/service/MemberService.java
@@ -48,18 +48,18 @@ public class MemberService {
 
     @Transactional
     public MemberMyPageResponse getMyPage(Long id) {
-        Member nowMember = memberRepository.findById(id).orElseThrow(
+        Member member = memberRepository.findById(id).orElseThrow(
             (IllegalArgumentException::new)
         );
-        return MemberMyPageResponse.fromEntity(nowMember);
+        return MemberMyPageResponse.fromEntity(member);
     }
 
     @Transactional
     public MemberMyBoardResponse getBoards(Long id) {
-        Member nowMember = memberRepository.findById(id).orElseThrow(
+        Member member = memberRepository.findById(id).orElseThrow(
             (IllegalArgumentException::new)
         );
-        List<ArrayList<?>> boards = boardRepository.findContentsByMemberIdOrderByPostIdDesc(nowMember.getMemberId());
+        List<ArrayList<?>> boards = boardRepository.findContentsByMemberIdOrderByPostIdDesc(member.getMemberId());
         return MemberMyBoardResponse.fromEntity(boards);
     }
 


### PR DESCRIPTION
## 작업 요약
- 게시글 작성 시 로그인한 회원임을 인증하도록 추가
- 게시글 작성 시 profId, memberId 함께 저장하도록 추가
- college 엔티티에 baseTimeEntity 제거

## Issue Link
#80 

## 문제점 및 어려움
- professor 객체 생성 시 연관된 엔티티가 많아 프록시 객체를 모두 불러오지 못함 -> DB에 값은 저장되나 401에러 발생

## 해결 방안
- boardCreateResponse DTO에서 발생하는 문제로 확인 -> professor 객체 자체를 매개변수로 받는 것이 아닌, professor.Id를 받도록 변경

## Reference
