### PR TITLE
Refactor: accessToken 유효시간 연장

### DIFF
--- a/src/main/java/com/example/gasip/global/security/JwtService.java
+++ b/src/main/java/com/example/gasip/global/security/JwtService.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class JwtService {
 
     private static final String SECRET_KEY = "secret_key";
-    private static final Duration ACCESS_DURATION = Duration.of(1, ChronoUnit.DAYS);
+    private static final Duration ACCESS_DURATION = Duration.of(1, ChronoUnit.WEEKS);
 
     public String issue(Long id, String email, Role role) {
         return JWT.create()


### PR DESCRIPTION
## 작업 요약
accessToken 유효기간 : - 1일 -> 1주일

## Issue Link
#94 

## 문제점 및 어려움
refreshToken이 없는 상태이므로, 프론트에서 accesstoken 만료 시 처리 작업 필요
## 해결 방안
프론트 파트에서 상태 코드 401을 확인한 후 처리할 것. 이후 redis 활용하여 refreshToken 발급 예정
## Reference
