### PR TITLE
Refactor: Comment create/Read 리팩토링

### DIFF
--- a/src/main/java/com/example/gasip/comment/controller/CommentController.java
+++ b/src/main/java/com/example/gasip/comment/controller/CommentController.java
@@ -47,7 +47,7 @@ public class CommentController {
 
     // 특정 게시글 댓글 read
     @GetMapping("{postId}")
-    public ResponseEntity<?> findCommentByBoard(@PathVariable Board postId) {
+    public ResponseEntity<?> findCommentByBoard(@PathVariable Long postId) {
         return ResponseEntity
             .ok()
             .body(

--- a/src/main/java/com/example/gasip/comment/dto/CommentCreateResponse.java
+++ b/src/main/java/com/example/gasip/comment/dto/CommentCreateResponse.java
@@ -1,23 +1,16 @@
 package com.example.gasip.comment.dto;
 
 import com.example.gasip.comment.model.Comment;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import lombok.*;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-@Data
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@SuperBuilder
-public class CommentDto implements Serializable {
+@Builder
+public class CommentCreateResponse {
     private Long postId;
     private Long memberId;
     private String content;
@@ -26,10 +19,10 @@ public class CommentDto implements Serializable {
     private Long parentId;
     private List<CommentDto> commentChildren = new ArrayList<>();
 
-    public static CommentDto fromEntity(Comment comment) {
+    public static CommentCreateResponse fromEntity(Comment comment) {
         // 부모댓글이 있는 경우
         if (comment.getParentComment() != null) {
-            return CommentDto.builder()
+            return CommentCreateResponse.builder()
                 .postId(comment.getBoard().getPostId())
                 .memberId(comment.getMember().getMemberId())
                 .content(comment.getContent())
@@ -39,12 +32,11 @@ public class CommentDto implements Serializable {
         }
         // 부모댓글이 없는 경우
         else {
-            return CommentDto.builder()
+            return CommentCreateResponse.builder()
                 .postId(comment.getBoard().getPostId())
                 .memberId(comment.getMember().getMemberId())
                 .content(comment.getContent())
                 .writer(comment.getWriter())
-                .commentChildren(comment.getCommentChildren().stream().map(CommentDto::fromEntity).collect(Collectors.toList()))
                 .build();
         }
 

--- a/src/main/java/com/example/gasip/comment/model/Comment.java
+++ b/src/main/java/com/example/gasip/comment/model/Comment.java
@@ -30,7 +30,7 @@ public class Comment extends BaseTimeEntity {
     private String writer;
     private Long commentLike;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "post_id")
     private Board board;
 
@@ -42,7 +42,7 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "parent_id")
     private Comment parentComment;
 
-    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.REMOVE)
     private List<Comment> commentChildren = new ArrayList<>();
 
 
@@ -57,6 +57,10 @@ public class Comment extends BaseTimeEntity {
 
     public void updateParent(Comment comment) {
         this.parentComment = comment;
+    }
+
+    public void updateCommentChildren(Comment comment) {
+        commentChildren.add(comment);
     }
 
 }

--- a/src/main/java/com/example/gasip/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/gasip/comment/repository/CommentRepository.java
@@ -1,9 +1,9 @@
 package com.example.gasip.comment.repository;
 
-import com.example.gasip.board.model.Board;
 import com.example.gasip.comment.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,13 +11,14 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 전체 조회
-    @Query("select c from Comment c where c.parentComment is NULL")
+    @Query("select c from Comment c where c.parentComment = null")
     List<Comment> findComment();
 
     // 부모 댓글 조회
     List<Comment> findCommentByParentComment(Comment parentComment_id);
 
     // 특정 게시글 댓글 조회
-    @Query("select c, b from Comment c, Board b where c.parentComment is NULL and c.board.postId = b.postId")
-    List<Comment> findCommentByBoard(Board postId);
+    @Query("select c from Comment c where c.board.postId = :postId")
+    List<Comment> findCommentByBoard(@Param("postId") Long postId);
+
 }

--- a/src/main/java/com/example/gasip/comment/service/CommentService.java
+++ b/src/main/java/com/example/gasip/comment/service/CommentService.java
@@ -3,6 +3,7 @@ package com.example.gasip.comment.service;
 import com.example.gasip.board.model.Board;
 import com.example.gasip.board.repository.BoardRepository;
 import com.example.gasip.comment.dto.CommentCreateRequest;
+import com.example.gasip.comment.dto.CommentCreateResponse;
 import com.example.gasip.comment.dto.CommentDto;
 import com.example.gasip.comment.model.Comment;
 import com.example.gasip.comment.repository.CommentRepository;
@@ -23,6 +24,22 @@ public class CommentService {
     private final BoardRepository boardRepository;
     private final MemberRepository memberRepository;
 
+    // 댓글 create
+    @Transactional
+    public CommentCreateResponse createComment(MemberDetails memberDetails, CommentCreateRequest commentCreateRequest, Long boardId) {
+        Member member = memberRepository.getReferenceById(memberDetails.getId());
+        Board board = boardRepository.findById(boardId).orElseThrow(IllegalArgumentException::new);
+        Comment comment = commentRepository.save(commentCreateRequest.toEntity(board,member));
+
+        Comment parentComment;
+        if (commentCreateRequest.getParentId() != null) {
+            parentComment = commentRepository.findById(commentCreateRequest.getParentId()).orElseThrow(IllegalArgumentException::new);
+            comment.updateParent(parentComment);
+            parentComment.updateCommentChildren(comment);
+        }
+        return CommentCreateResponse.fromEntity(comment);
+    }
+
     // 댓글 목록 전체 조회
     @Transactional(readOnly = true)
     public List<CommentDto> CommentList() {
@@ -34,35 +51,11 @@ public class CommentService {
 
     // 특정 게시글 댓글 조회
     @Transactional(readOnly = true)
-    public List<CommentDto> findCommentByBoard(Board postId) {
+    public List<CommentDto> findCommentByBoard(Long postId) {
         return commentRepository.findCommentByBoard(postId)
             .stream()
             .map(CommentDto::fromEntity)
             .collect(Collectors.toList());
-    }
-
-    // 댓글 create
-    @Transactional
-    public CommentDto createComment(MemberDetails memberDetails, CommentCreateRequest commentCreateRequest, Long boardId) {
-        Member member = memberRepository.getReferenceById(memberDetails.getId());
-        Board board = boardRepository.findById(boardId).orElseThrow(IllegalArgumentException::new);
-        Comment comment = commentRepository.save(commentCreateRequest.toEntity(board,member));
-
-        Comment parentComment;
-        if (commentCreateRequest.getParentId() != null) {
-            parentComment = commentRepository.findById(commentCreateRequest.getParentId()).orElseThrow(IllegalArgumentException::new);
-            comment.updateParent(parentComment);
-        }
-//        Comment comment = commentRepository.save(
-//                Comment.createComment(
-//                commentCreateRequest.getContent(),
-//                boardRepository.findById(commentCreateRequest.getPostId()).orElseThrow(BoardNotFoundException::new),
-//                commentCreateRequest.getWriter(),
-//                commentCreateRequest.getParentId() != null ?
-//                    commentRepository.findById(commentCreateRequest.getParentId()).orElseThrow(CommentNotFoundException::new) : null)
-//        );
-
-        return CommentDto.fromEntity(comment);
     }
 
     // 댓글 delete


### PR DESCRIPTION
## 작업 요약
- 대댓글 기능 리팩토링(무한대댓글 -> 대댓글)
- postId 별로 조회 기능 리팩토링

## Issue Link
#89 

## 문제점 및 어려움
1. parentId 유무에 따라 if/else문으로 분기되어 dto 출력 -> 더 깔끔한 코드가 있는지 조사 필요
2. CommentDto의 fromEntity 내 getCommentChildern 은 stream으로 묶었기 때문에 대댓글이 모두 하나씩 fromEntity 메서드를 거친 후 작업(1개 댓글에 10개 대댓글이 있다면 fromEntity는 11번 호츌) -> 성능상 문제 없는지 조사 필요

## 해결 방안
레퍼런스 참고 후 더 유지보수 및 성능적으로 개선이 가능한 방법 서칭

## Reference
