### PR TITLE
Feat: Board 수정/삭제 시 사용자 인증 로직 추가

### DIFF
--- a/src/main/generated/com/example/gasip/board/dto/QBoardReadResponse.java
+++ b/src/main/generated/com/example/gasip/board/dto/QBoardReadResponse.java
@@ -1,0 +1,21 @@
+package com.example.gasip.board.dto;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.ConstructorExpression;
+import javax.annotation.processing.Generated;
+
+/**
+ * com.example.gasip.board.dto.QBoardReadResponse is a Querydsl Projection type for BoardReadResponse
+ */
+@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
+public class QBoardReadResponse extends ConstructorExpression<BoardReadResponse> {
+
+    private static final long serialVersionUID = 973240231L;
+
+    public QBoardReadResponse(com.querydsl.core.types.Expression<java.time.LocalDateTime> regDate, com.querydsl.core.types.Expression<java.time.LocalDateTime> updateDate, com.querydsl.core.types.Expression<Long> postId, com.querydsl.core.types.Expression<String> content, com.querydsl.core.types.Expression<Long> clickCount, com.querydsl.core.types.Expression<Long> likeCount, com.querydsl.core.types.Expression<Long> profId) {
+        super(BoardReadResponse.class, new Class<?>[]{java.time.LocalDateTime.class, java.time.LocalDateTime.class, long.class, String.class, long.class, long.class, long.class}, regDate, updateDate, postId, content, clickCount, likeCount, profId);
+    }
+
+}
+

--- a/src/main/generated/com/example/gasip/board/model/QBoard.java
+++ b/src/main/generated/com/example/gasip/board/model/QBoard.java
@@ -1,0 +1,68 @@
+package com.example.gasip.board.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBoard is a Querydsl query type for Board
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBoard extends EntityPathBase<Board> {
+
+    private static final long serialVersionUID = -509021414L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QBoard board = new QBoard("board");
+
+    public final com.example.gasip.global.entity.QBaseTimeEntity _super = new com.example.gasip.global.entity.QBaseTimeEntity(this);
+
+    public final NumberPath<Long> clickCount = createNumber("clickCount", Long.class);
+
+    public final StringPath content = createString("content");
+
+    public final NumberPath<Long> likeCount = createNumber("likeCount", Long.class);
+
+    public final com.example.gasip.member.model.QMember member;
+
+    public final NumberPath<Long> postId = createNumber("postId", Long.class);
+
+    public final com.example.gasip.professor.model.QProfessor professor;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updateDate = _super.updateDate;
+
+    public QBoard(String variable) {
+        this(Board.class, forVariable(variable), INITS);
+    }
+
+    public QBoard(Path<? extends Board> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QBoard(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QBoard(PathMetadata metadata, PathInits inits) {
+        this(Board.class, metadata, inits);
+    }
+
+    public QBoard(Class<? extends Board> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new com.example.gasip.member.model.QMember(forProperty("member")) : null;
+        this.professor = inits.isInitialized("professor") ? new com.example.gasip.professor.model.QProfessor(forProperty("professor"), inits.get("professor")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/gasip/category/model/QCategory.java
+++ b/src/main/generated/com/example/gasip/category/model/QCategory.java
@@ -1,0 +1,61 @@
+package com.example.gasip.category.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCategory is a Querydsl query type for Category
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCategory extends EntityPathBase<Category> {
+
+    private static final long serialVersionUID = 1383062228L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCategory category = new QCategory("category");
+
+    public final ListPath<Category, QCategory> children = this.<Category, QCategory>createList("children", Category.class, QCategory.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> collegeId = createNumber("collegeId", Long.class);
+
+    public final StringPath collegeName = createString("collegeName");
+
+    public final NumberPath<Long> Id = createNumber("Id", Long.class);
+
+    public final NumberPath<Long> majorId = createNumber("majorId", Long.class);
+
+    public final StringPath majorName = createString("majorName");
+
+    public final QCategory parentCategory;
+
+    public QCategory(String variable) {
+        this(Category.class, forVariable(variable), INITS);
+    }
+
+    public QCategory(Path<? extends Category> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCategory(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCategory(PathMetadata metadata, PathInits inits) {
+        this(Category.class, metadata, inits);
+    }
+
+    public QCategory(Class<? extends Category> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.parentCategory = inits.isInitialized("parentCategory") ? new QCategory(forProperty("parentCategory"), inits.get("parentCategory")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/gasip/college/model/QCollege.java
+++ b/src/main/generated/com/example/gasip/college/model/QCollege.java
@@ -1,0 +1,39 @@
+package com.example.gasip.college.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QCollege is a Querydsl query type for College
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCollege extends EntityPathBase<College> {
+
+    private static final long serialVersionUID = 413371772L;
+
+    public static final QCollege college = new QCollege("college");
+
+    public final NumberPath<Long> collegeId = createNumber("collegeId", Long.class);
+
+    public final StringPath collegeName = createString("collegeName");
+
+    public QCollege(String variable) {
+        super(College.class, forVariable(variable));
+    }
+
+    public QCollege(Path<? extends College> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QCollege(PathMetadata metadata) {
+        super(College.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/example/gasip/comment/model/QComment.java
+++ b/src/main/generated/com/example/gasip/comment/model/QComment.java
@@ -1,0 +1,73 @@
+package com.example.gasip.comment.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QComment is a Querydsl query type for Comment
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QComment extends EntityPathBase<Comment> {
+
+    private static final long serialVersionUID = 432449804L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QComment comment = new QComment("comment");
+
+    public final com.example.gasip.global.entity.QBaseTimeEntity _super = new com.example.gasip.global.entity.QBaseTimeEntity(this);
+
+    public final com.example.gasip.board.model.QBoard board;
+
+    public final ListPath<Comment, QComment> commentChildren = this.<Comment, QComment>createList("commentChildren", Comment.class, QComment.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> commentId = createNumber("commentId", Long.class);
+
+    public final NumberPath<Long> commentLike = createNumber("commentLike", Long.class);
+
+    public final StringPath content = createString("content");
+
+    public final com.example.gasip.member.model.QMember member;
+
+    public final QComment parentComment;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updateDate = _super.updateDate;
+
+    public final StringPath writer = createString("writer");
+
+    public QComment(String variable) {
+        this(Comment.class, forVariable(variable), INITS);
+    }
+
+    public QComment(Path<? extends Comment> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QComment(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QComment(PathMetadata metadata, PathInits inits) {
+        this(Comment.class, metadata, inits);
+    }
+
+    public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.board = inits.isInitialized("board") ? new com.example.gasip.board.model.QBoard(forProperty("board"), inits.get("board")) : null;
+        this.member = inits.isInitialized("member") ? new com.example.gasip.member.model.QMember(forProperty("member")) : null;
+        this.parentComment = inits.isInitialized("parentComment") ? new QComment(forProperty("parentComment"), inits.get("parentComment")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/gasip/global/entity/QBaseTimeEntity.java
+++ b/src/main/generated/com/example/gasip/global/entity/QBaseTimeEntity.java
@@ -1,0 +1,39 @@
+package com.example.gasip.global.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseTimeEntity is a Querydsl query type for BaseTimeEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseTimeEntity extends EntityPathBase<BaseTimeEntity> {
+
+    private static final long serialVersionUID = -971326656L;
+
+    public static final QBaseTimeEntity baseTimeEntity = new QBaseTimeEntity("baseTimeEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> regDate = createDateTime("regDate", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updateDate = createDateTime("updateDate", java.time.LocalDateTime.class);
+
+    public QBaseTimeEntity(String variable) {
+        super(BaseTimeEntity.class, forVariable(variable));
+    }
+
+    public QBaseTimeEntity(Path<? extends BaseTimeEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseTimeEntity(PathMetadata metadata) {
+        super(BaseTimeEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/example/gasip/major/model/QMajor.java
+++ b/src/main/generated/com/example/gasip/major/model/QMajor.java
@@ -1,0 +1,53 @@
+package com.example.gasip.major.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMajor is a Querydsl query type for Major
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMajor extends EntityPathBase<Major> {
+
+    private static final long serialVersionUID = -1848124352L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMajor major = new QMajor("major");
+
+    public final com.example.gasip.college.model.QCollege college;
+
+    public final NumberPath<Long> majorId = createNumber("majorId", Long.class);
+
+    public final StringPath majorName = createString("majorName");
+
+    public QMajor(String variable) {
+        this(Major.class, forVariable(variable), INITS);
+    }
+
+    public QMajor(Path<? extends Major> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMajor(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMajor(PathMetadata metadata, PathInits inits) {
+        this(Major.class, metadata, inits);
+    }
+
+    public QMajor(Class<? extends Major> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.college = inits.isInitialized("college") ? new com.example.gasip.college.model.QCollege(forProperty("college")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/gasip/member/model/QMember.java
+++ b/src/main/generated/com/example/gasip/member/model/QMember.java
@@ -1,0 +1,45 @@
+package com.example.gasip.member.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = -1170449900L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> memberId = createNumber("memberId", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public final StringPath password = createString("password");
+
+    public final EnumPath<com.example.gasip.global.constant.Role> role = createEnum("role", com.example.gasip.global.constant.Role.class);
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/example/gasip/professor/model/QProfessor.java
+++ b/src/main/generated/com/example/gasip/professor/model/QProfessor.java
@@ -1,0 +1,53 @@
+package com.example.gasip.professor.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QProfessor is a Querydsl query type for Professor
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QProfessor extends EntityPathBase<Professor> {
+
+    private static final long serialVersionUID = -742031956L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QProfessor professor = new QProfessor("professor");
+
+    public final com.example.gasip.major.model.QMajor major;
+
+    public final NumberPath<Long> profId = createNumber("profId", Long.class);
+
+    public final StringPath profName = createString("profName");
+
+    public QProfessor(String variable) {
+        this(Professor.class, forVariable(variable), INITS);
+    }
+
+    public QProfessor(Path<? extends Professor> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QProfessor(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QProfessor(PathMetadata metadata, PathInits inits) {
+        this(Professor.class, metadata, inits);
+    }
+
+    public QProfessor(Class<? extends Professor> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.major = inits.isInitialized("major") ? new com.example.gasip.major.model.QMajor(forProperty("major"), inits.get("major")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/gasip/professordetail/model/QProfessorDetail.java
+++ b/src/main/generated/com/example/gasip/professordetail/model/QProfessorDetail.java
@@ -1,0 +1,53 @@
+package com.example.gasip.professordetail.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QProfessorDetail is a Querydsl query type for ProfessorDetail
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QProfessorDetail extends EntityPathBase<ProfessorDetail> {
+
+    private static final long serialVersionUID = 1264749230L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QProfessorDetail professorDetail = new QProfessorDetail("professorDetail");
+
+    public final com.example.gasip.major.model.QMajor major;
+
+    public final NumberPath<Long> profId = createNumber("profId", Long.class);
+
+    public final StringPath profName = createString("profName");
+
+    public QProfessorDetail(String variable) {
+        this(ProfessorDetail.class, forVariable(variable), INITS);
+    }
+
+    public QProfessorDetail(Path<? extends ProfessorDetail> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QProfessorDetail(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QProfessorDetail(PathMetadata metadata, PathInits inits) {
+        this(ProfessorDetail.class, metadata, inits);
+    }
+
+    public QProfessorDetail(Class<? extends ProfessorDetail> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.major = inits.isInitialized("major") ? new com.example.gasip.major.model.QMajor(forProperty("major"), inits.get("major")) : null;
+    }
+
+}
+

--- a/src/main/java/com/example/gasip/board/controller/BoardController.java
+++ b/src/main/java/com/example/gasip/board/controller/BoardController.java
@@ -72,13 +72,14 @@ public class BoardController {
     @PutMapping("/{boardId}")
     @Operation(summary = "게시글 수정 요청", description = "게시글을 수정을 요청합니다.", tags = { "Board Controller" })
     public ResponseEntity<?> editBoard(
+            @AuthenticationPrincipal MemberDetails memberDetails,
             @PathVariable Long boardId,
             @RequestBody @Valid BoardUpdateRequest boardUpdateRequest) {
         return ResponseEntity
             .ok()
             .body(
                 ApiUtils.success(
-                    boardService.editBoard(boardId,boardUpdateRequest)
+                    boardService.editBoard(memberDetails,boardId,boardUpdateRequest)
                 )
             );
 
@@ -86,12 +87,14 @@ public class BoardController {
 
     @DeleteMapping("/{boardId}")
     @Operation(summary = "게시글 삭제 요청", description = "게시글 삭제를 요청합니다.", tags = { "Board Controller" })
-    public ResponseEntity<?> deleteBoard(@PathVariable Long boardId) {
+    public ResponseEntity<?> deleteBoard(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @PathVariable Long boardId) {
         return ResponseEntity
             .ok()
             .body(
                 ApiUtils.success(
-                    boardService.deleteBoard(boardId)
+                    boardService.deleteBoard(memberDetails,boardId)
                 )
             );
 

--- a/src/main/java/com/example/gasip/board/service/BoardService.java
+++ b/src/main/java/com/example/gasip/board/service/BoardService.java
@@ -51,16 +51,25 @@ public class BoardService {
         return BoardReadResponse.fromEntity(board);
     }
     @Transactional
-    public BoardUpdateResponse editBoard(Long boardId,BoardUpdateRequest boardUpdateRequest) {
-        Board board = validateBoardEmpty(boardId);
+    public BoardUpdateResponse editBoard(MemberDetails memberDetails,Long boardId,BoardUpdateRequest boardUpdateRequest) {
+        Board board = validatedBoardWritter(memberDetails, boardId);
         board.updateBoard(boardUpdateRequest.getContent());
         return BoardUpdateResponse.fromEntity(board);
     }
     @Transactional
-    public String deleteBoard(Long boardId) {
-        validateBoardEmpty(boardId);
+    public String deleteBoard(MemberDetails memberDetails,Long boardId) {
+        validatedBoardWritter(memberDetails, boardId);
         boardRepository.deleteById(boardId);
         return boardId + "번 게시글이 삭제되었습니다.";
+    }
+
+    private Board validatedBoardWritter(MemberDetails memberDetails, Long boardId) {
+        Board board = validateBoardEmpty(boardId);
+        Member member = memberRepository.getReferenceById(memberDetails.getId());
+        if (!member.getMemberId().equals(board.getMember().getMemberId())) {
+            throw new IllegalArgumentException();
+        }
+        return board;
     }
 
     private Board validateBoardEmpty(Long boardId) {

--- a/src/main/java/com/example/gasip/comment/dto/CommentDto.java
+++ b/src/main/java/com/example/gasip/comment/dto/CommentDto.java
@@ -29,24 +29,32 @@ public class CommentDto implements Serializable {
     public static CommentDto fromEntity(Comment comment) {
         // 부모댓글이 있는 경우
         if (comment.getParentComment() != null) {
-            return CommentDto.builder()
-                .postId(comment.getBoard().getPostId())
-                .memberId(comment.getMember().getMemberId())
-                .content(comment.getContent())
-                .writer(comment.getWriter())
-                .parentId(comment.getParentComment().getCommentId())
-                .build();
+            return buildCommentDtoWithParentId(comment);
         }
         // 부모댓글이 없는 경우
         else {
-            return CommentDto.builder()
-                .postId(comment.getBoard().getPostId())
-                .memberId(comment.getMember().getMemberId())
-                .content(comment.getContent())
-                .writer(comment.getWriter())
-                .commentChildren(comment.getCommentChildren().stream().map(CommentDto::fromEntity).collect(Collectors.toList()))
-                .build();
+            return buildCommentDtoWithChildrenComment(comment);
         }
 
+    }
+
+    private static CommentDto buildCommentDtoWithChildrenComment(Comment comment) {
+        return CommentDto.builder()
+            .postId(comment.getBoard().getPostId())
+            .memberId(comment.getMember().getMemberId())
+            .content(comment.getContent())
+            .writer(comment.getWriter())
+            .commentChildren(comment.getCommentChildren().stream().map(CommentDto::fromEntity).collect(Collectors.toList()))
+            .build();
+    }
+
+    private static CommentDto buildCommentDtoWithParentId(Comment comment) {
+        return CommentDto.builder()
+            .postId(comment.getBoard().getPostId())
+            .memberId(comment.getMember().getMemberId())
+            .content(comment.getContent())
+            .writer(comment.getWriter())
+            .parentId(comment.getParentComment().getCommentId())
+            .build();
     }
 }


### PR DESCRIPTION
## 작업 요약
- editBoard 메서드에서 memberId 확인 로직 추가
- deleteBoard 메서드에서 memberId 확인 로직 추가
- [별도] 이전 커밋 시 Q파일 미추가로 인한 Q파일 추가

## Issue Link
#103 
#101 

## 문제점 및 어려움

## 해결 방안

## Reference
