### PR TITLE
feat : 공통 예외처리 적용

### DIFF
--- a/src/main/java/com/example/gasip/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/gasip/comment/repository/CommentRepository.java
@@ -18,6 +18,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findCommentByParentComment(Comment parentComment_id);
 
     // 특정 게시글 댓글 조회
+    // 찾을게 없어도 error 코드 안뜸 -> 수정 필요
     @Query("select c from Comment c where c.board.postId = :postId")
     List<Comment> findCommentByBoard(@Param("postId") Long postId);
 

--- a/src/main/java/com/example/gasip/global/api/ApiUtils.java
+++ b/src/main/java/com/example/gasip/global/api/ApiUtils.java
@@ -14,7 +14,7 @@ public class ApiUtils {
         return new ApiResult<>(false, null, new ApiError(throwable, status));
     }
 
-    public static ApiResult<?> error(String message, HttpStatus status) {
-        return new ApiResult<>(false, null, new ApiError(message, status));
+    public static ApiResult<?> error(String message,HttpStatus status) {
+        return new ApiResult<>(false, null, new ApiError(message,status));
     }
 }

--- a/src/main/java/com/example/gasip/global/exception/AccessForbiddenException.java
+++ b/src/main/java/com/example/gasip/global/exception/AccessForbiddenException.java
@@ -1,0 +1,17 @@
+package com.example.gasip.global.exception;
+
+import com.example.gasip.global.constant.ErrorCode;
+
+public class AccessForbiddenException extends RuntimeException {
+    public AccessForbiddenException() {
+        super(ErrorCode.ACCESS_FORBIDDEN.getMessage());
+    }
+
+    public AccessForbiddenException(String message) {
+        super(message);
+    }
+
+    public AccessForbiddenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/gasip/global/exception/DuplicateEmailException.java
+++ b/src/main/java/com/example/gasip/global/exception/DuplicateEmailException.java
@@ -1,0 +1,18 @@
+package com.example.gasip.global.exception;
+
+
+import com.example.gasip.global.constant.ErrorCode;
+
+public class DuplicateEmailException extends RuntimeException {
+    public DuplicateEmailException() {
+        super(ErrorCode.DUPLICATE_EMAIL.getMessage());
+    }
+
+    public DuplicateEmailException(String message) {
+        super(message);
+    }
+
+    public DuplicateEmailException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/gasip/global/exception/DuplicatePhoneNumberException.java
+++ b/src/main/java/com/example/gasip/global/exception/DuplicatePhoneNumberException.java
@@ -1,0 +1,18 @@
+package com.example.gasip.global.exception;
+
+
+import com.example.gasip.global.constant.ErrorCode;
+
+public class DuplicatePhoneNumberException extends RuntimeException {
+    public DuplicatePhoneNumberException() {
+        super(ErrorCode.DUPLICATE_PHONENUMBER.getMessage());
+    }
+
+    public DuplicatePhoneNumberException(String message) {
+        super(message);
+    }
+
+    public DuplicatePhoneNumberException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/gasip/global/exception/InvalidParamException.java
+++ b/src/main/java/com/example/gasip/global/exception/InvalidParamException.java
@@ -1,0 +1,18 @@
+package com.example.gasip.global.exception;
+
+import com.example.gasip.global.constant.ErrorCode;
+
+public class InvalidParamException extends RuntimeException {
+
+    public InvalidParamException() {
+        super(ErrorCode.INVALID_PARAM_ERROR.getMessage());
+    }
+
+    public InvalidParamException(String message) {
+        super(message);
+    }
+
+    public InvalidParamException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/gasip/global/exception/MemberNotFoundException.java
+++ b/src/main/java/com/example/gasip/global/exception/MemberNotFoundException.java
@@ -1,0 +1,17 @@
+package com.example.gasip.global.exception;
+
+import com.example.gasip.global.constant.ErrorCode;
+
+public class MemberNotFoundException extends RuntimeException {
+    public MemberNotFoundException() {
+        super(ErrorCode.NOT_FOUND_MEMBER.getMessage());
+    }
+
+    public MemberNotFoundException(String message) {
+        super(message);
+    }
+
+    public MemberNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/gasip/global/exception/NoStockException.java
+++ b/src/main/java/com/example/gasip/global/exception/NoStockException.java
@@ -1,0 +1,19 @@
+package com.example.gasip.global.exception;
+
+import com.example.gasip.global.constant.ErrorCode;
+
+public class NoStockException extends RuntimeException {
+
+    public NoStockException() {
+        super(ErrorCode.NO_STOCK_ERROR.getMessage());
+    }
+
+    public NoStockException(String message) {
+        super(message);
+    }
+
+    public NoStockException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/com/example/gasip/global/exception/NoSuchEntityException.java
+++ b/src/main/java/com/example/gasip/global/exception/NoSuchEntityException.java
@@ -1,0 +1,19 @@
+package com.example.gasip.global.exception;
+
+
+import com.example.gasip.global.constant.ErrorCode;
+
+public class NoSuchEntityException extends RuntimeException {
+
+    public NoSuchEntityException() {
+        super(ErrorCode.NO_SUCH_ENTITY.getMessage());
+    }
+
+    public NoSuchEntityException(String message) {
+        super(message);
+    }
+
+    public NoSuchEntityException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/gasip/global/exception/handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/example/gasip/global/exception/handler/GlobalControllerAdvice.java
@@ -1,13 +1,20 @@
 package com.example.gasip.global.exception.handler;
 
 import com.example.gasip.global.api.ApiUtils;
+import com.example.gasip.global.constant.ErrorCode;
+import com.example.gasip.global.exception.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -17,12 +24,12 @@ public class GlobalControllerAdvice {
     private final MessageSource messageSource;
 
     @ExceptionHandler({
-//        NoSuchEntityException.class,
-//        DuplicateEmailException.class,
-//        InvalidParamException.class,
-//        NoStockException.class,
-//        MemberNotFoundException.class,
-//        DuplicatePhoneNumberException.class
+        NoSuchEntityException.class,
+        DuplicateEmailException.class,
+        InvalidParamException.class,
+        NoStockException.class,
+        MemberNotFoundException.class,
+        DuplicatePhoneNumberException.class
     })
     public ResponseEntity<?> handleCustomException(
         RuntimeException ex
@@ -32,8 +39,98 @@ public class GlobalControllerAdvice {
         return ResponseEntity
             .badRequest()
             .body(
-                ApiUtils.error(ex.getMessage(), HttpStatus.BAD_REQUEST)
+                ApiUtils.error(ex.getMessage(),HttpStatus.BAD_REQUEST)
             );
     }
 
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<?> handleAuthenticationException(
+        AuthenticationException ex
+    ) {
+        log.error("handling {}, message : {}", ex.getClass().toString(), ex.getMessage());
+
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(
+                ApiUtils.error(ErrorCode.UNAUTHORIZED.getMessage(),HttpStatus.UNAUTHORIZED)
+            );
+    }
+
+    @ExceptionHandler(AccessForbiddenException.class)
+    public ResponseEntity<?> handleAccessForbidden(
+        AccessForbiddenException ex
+    ) {
+        log.error("handling {}, message : {}", ex.getClass().toString(), ex.getMessage());
+
+        return ResponseEntity
+            .status(HttpStatus.FORBIDDEN)
+            .body(
+                ApiUtils.error(ex.getMessage(),HttpStatus.FORBIDDEN)
+            );
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<?> handleHttpMessageNotReadableException(
+        HttpMessageNotReadableException ex
+    ) {
+        log.error("handling {}, message : {}", ex.getClass().toString(), ex.getMessage());
+
+        return ResponseEntity
+            .badRequest()
+            .body(
+                ApiUtils.error(ErrorCode.PARAM_PARSING_MAPPING_ERROR.getMessage(),HttpStatus.BAD_REQUEST)
+            );
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<?> handleMethodArgumentTypeMismatchException(
+        MethodArgumentTypeMismatchException ex
+    ) {
+        log.error("handling {}, message : {}", ex.getClass().toString(), ex.getMessage());
+
+        return ResponseEntity
+            .badRequest()
+            .body(
+                ApiUtils.error(ErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH.getMessage(),HttpStatus.BAD_REQUEST)
+            );
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<?> handleNoHandlerFoundException(
+        NoHandlerFoundException ex
+    ) {
+        log.error("handling {}, message : {}", ex.getClass().toString(), ex.getMessage());
+
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(
+                ApiUtils.error(ErrorCode.NO_HANDLER_FOUND.getMessage(),HttpStatus.NOT_FOUND)
+            );
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<?> handleHttpRequestMethodNotSupportedException(
+        HttpRequestMethodNotSupportedException ex
+    ) {
+        log.error("handling {}, message : {}", ex.getClass().toString(), ex.getMessage());
+
+        return ResponseEntity
+            .status(HttpStatus.METHOD_NOT_ALLOWED)
+            .body(
+                ApiUtils.error(ErrorCode.HTTP_REQUEST_METHOD_NOT_SUPPORTED.getMessage(),HttpStatus.METHOD_NOT_ALLOWED)
+            );
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleException(
+        Exception ex
+    ) {
+        log.error("handling {}, message : {}", ex.getClass().toString(), ex.getMessage());
+
+        return ResponseEntity
+            .internalServerError()
+            .body(
+                ApiUtils.error(ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),HttpStatus.INTERNAL_SERVER_ERROR)
+            );
+    }
 }


### PR DESCRIPTION
## 작업 요약
- global Controller 기반 공통 예외처리 로직 생성

## Issue Link
#91 

## 문제점 및 어려움
1. getBoardDetail 시 성공/실패 메세지 동시 출력
2. ReadCommentByBoardId 시 무조건 성공으로 출력

## 해결 방안
1. 문제 확인 필요
2. JPQL 사용 문제이므로 다른 방법 있는지 확인

## Reference
