### PR TITLE
Feat : 교수 평점 칼럼 추가

### DIFF
--- a/src/main/generated/com/example/gasip/board/dto/QBoardReadResponse.java
+++ b/src/main/generated/com/example/gasip/board/dto/QBoardReadResponse.java
@@ -13,8 +13,8 @@ public class QBoardReadResponse extends ConstructorExpression<BoardReadResponse>
 
     private static final long serialVersionUID = 973240231L;
 
-    public QBoardReadResponse(com.querydsl.core.types.Expression<java.time.LocalDateTime> regDate, com.querydsl.core.types.Expression<java.time.LocalDateTime> updateDate, com.querydsl.core.types.Expression<Long> postId, com.querydsl.core.types.Expression<String> content, com.querydsl.core.types.Expression<Long> clickCount, com.querydsl.core.types.Expression<Long> likeCount, com.querydsl.core.types.Expression<Long> profId) {
-        super(BoardReadResponse.class, new Class<?>[]{java.time.LocalDateTime.class, java.time.LocalDateTime.class, long.class, String.class, long.class, long.class, long.class}, regDate, updateDate, postId, content, clickCount, likeCount, profId);
+    public QBoardReadResponse(com.querydsl.core.types.Expression<java.time.LocalDateTime> regDate, com.querydsl.core.types.Expression<java.time.LocalDateTime> updateDate, com.querydsl.core.types.Expression<Long> postId, com.querydsl.core.types.Expression<String> content, com.querydsl.core.types.Expression<Long> clickCount, com.querydsl.core.types.Expression<Long> likeCount, com.querydsl.core.types.Expression<Long> profId, com.querydsl.core.types.Expression<Integer> gradePoint) {
+        super(BoardReadResponse.class, new Class<?>[]{java.time.LocalDateTime.class, java.time.LocalDateTime.class, long.class, String.class, long.class, long.class, long.class, int.class}, regDate, updateDate, postId, content, clickCount, likeCount, profId, gradePoint);
     }
 
 }

--- a/src/main/generated/com/example/gasip/board/model/QBoard.java
+++ b/src/main/generated/com/example/gasip/board/model/QBoard.java
@@ -30,6 +30,8 @@ public class QBoard extends EntityPathBase<Board> {
 
     public final StringPath content = createString("content");
 
+    public final NumberPath<Integer> gradePoint = createNumber("gradePoint", Integer.class);
+
     public final NumberPath<Long> likeCount = createNumber("likeCount", Long.class);
 
     public final com.example.gasip.member.model.QMember member;

--- a/src/main/java/com/example/gasip/board/controller/BoardController.java
+++ b/src/main/java/com/example/gasip/board/controller/BoardController.java
@@ -1,7 +1,6 @@
 package com.example.gasip.board.controller;
 
 import com.example.gasip.board.dto.BoardCreateRequest;
-import com.example.gasip.board.dto.BoardReadRequest;
 import com.example.gasip.board.dto.BoardUpdateRequest;
 import com.example.gasip.board.service.BoardService;
 import com.example.gasip.global.api.ApiUtils;

--- a/src/main/java/com/example/gasip/board/dto/BoardCreateRequest.java
+++ b/src/main/java/com/example/gasip/board/dto/BoardCreateRequest.java
@@ -27,6 +27,9 @@ public class BoardCreateRequest extends BaseTimeEntity {
     private Professor professor;
     @Schema(description = "게시글 작성한 사용자")
     private Member member;
+    @NotNull
+    @Schema(description = "교수 평점")
+    private int gradePoint;
 
 
     public Board toEntity(Professor prof, Member mem) {
@@ -36,6 +39,7 @@ public class BoardCreateRequest extends BaseTimeEntity {
                 .likeCount(likeCount)
                 .professor(prof)
                 .member(mem)
+                .gradePoint(gradePoint)
                 .build();
     }
 

--- a/src/main/java/com/example/gasip/board/dto/BoardCreateResponse.java
+++ b/src/main/java/com/example/gasip/board/dto/BoardCreateResponse.java
@@ -29,14 +29,17 @@ public class BoardCreateResponse extends BaseTimeEntity {
     @NotNull
     @Schema(description = "게시글과 관련된 교수 정보")
     private Long profId;
+    @Schema(description = "교수 평점")
+    private int gradePoint;
 
-    public BoardCreateResponse(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Professor professor) {
+    public BoardCreateResponse(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Professor professor,int gradePoint) {
         super(regDate, updateDate);
         this.postId = postId;
         this.content = content;
         this.clickCount = 0L;
         this.likeCount = 0L;
         this.profId = professor.getProfId();
+        this.gradePoint = gradePoint;
     }
 
     //fromEntity메서드 개발
@@ -49,6 +52,7 @@ public class BoardCreateResponse extends BaseTimeEntity {
                 .clickCount(0L)
                 .likeCount(0L)
                 .profId(board.getProfessor().getProfId())
+                .gradePoint(board.getGradePoint())
                 .build();
     }
 

--- a/src/main/java/com/example/gasip/board/dto/BoardReadResponse.java
+++ b/src/main/java/com/example/gasip/board/dto/BoardReadResponse.java
@@ -31,15 +31,18 @@ public class BoardReadResponse extends BaseTimeEntity {
     @NotNull
     @Schema(description = "게시글과 관련된 교수 정보")
     private Long profId;
+    @Schema(description = "교수 평점")
+    private int gradePoint;
 
     @QueryProjection
-    public BoardReadResponse(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Long clickCount, Long likeCount, Long profId) {
+    public BoardReadResponse(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Long clickCount, Long likeCount, Long profId,int gradePoint) {
         super(regDate, updateDate);
         this.postId = postId;
         this.content = content;
         this.clickCount = clickCount;
         this.likeCount = likeCount;
         this.profId = profId;
+        this.gradePoint = gradePoint;
     }
     public static BoardReadResponse fromEntity(Board board) {
         return BoardReadResponse.builder()

--- a/src/main/java/com/example/gasip/board/model/Board.java
+++ b/src/main/java/com/example/gasip/board/model/Board.java
@@ -57,7 +57,13 @@ public class Board extends BaseTimeEntity {
     @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
-    public Board(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Long clickCount, Long likeCount, Professor professor, Member member) {
+    @Column(nullable = false)
+    @Schema(description = "교수 평점")
+    @ColumnDefault("0")
+    private int gradePoint;
+
+
+    public Board(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Long clickCount, Long likeCount, Professor professor, Member member,int gradePoint) {
         super(regDate, updateDate);
         this.postId = postId;
         this.content = content;
@@ -65,6 +71,7 @@ public class Board extends BaseTimeEntity {
         this.likeCount = likeCount;
         this.professor = professor;
         this.member = member;
+        this.gradePoint = gradePoint;
     }
     public void updateBoard(String content) {
         this.content = content;

--- a/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustomImpl.java
@@ -36,7 +36,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
     public List<BoardReadResponse> findAllBoard() {
         return queryFactory
                 .select(new QBoardReadResponse(
-                        board.regDate, board.updateDate, board.postId, board.content, board.clickCount, board.likeCount, board.professor.profId))
+                        board.regDate, board.updateDate, board.postId, board.content, board.clickCount, board.likeCount, board.professor.profId, board.gradePoint))
                 .from(board)
                 .fetch();
     }


### PR DESCRIPTION
## 작업 요약
- queryDSL Q파일 재생성
- 엔티티 및 dto에 gradePoint 칼럼 추가

## Issue Link
#135 

## 문제점 및 어려움
- 매 게시글 작성 시 교수 평점을 입력할 수 있게 놔둔다면 평점테러의 가능성 존재. 이는 평점 기능의 기능을 상실

## 해결 방안
- 스프링 배치를 이용해 평점 작성 이후 3일 동안 평점 추가 작성 못하도록 설정
## Reference
