### PR TITLE
Feat : 교수 평균 평점 조회 로직 추가

### DIFF
--- a/src/main/java/com/example/gasip/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/gasip/board/repository/BoardRepository.java
@@ -12,7 +12,8 @@ import java.util.List;
 @Repository
 public interface BoardRepository extends JpaRepository<Board,Long>,BoardRepositoryCustom {
     Page<Board> findAllByOrderByRegDateDesc(Pageable pageable);
-
     Page<Board> findByProfessorOrderByLikeCountDesc(Professor professor,Pageable pageable);
+
+    List<Board> findAllByProfessor(Professor professor);
 
 }

--- a/src/main/java/com/example/gasip/professor/dto/ProfessorResponse.java
+++ b/src/main/java/com/example/gasip/professor/dto/ProfessorResponse.java
@@ -18,6 +18,8 @@ public class ProfessorResponse {
     private Long majorId;
     @Schema(description = "교수 전공 이름")
     private String majorName;
+    @Schema(description = "교수 평균 평점")
+    private String professorAverageGradePoint;
 
     public static ProfessorResponse fromEntity(Professor professor) {
         return ProfessorResponse.builder()
@@ -25,6 +27,7 @@ public class ProfessorResponse {
                 .majorId(professor.getMajor().getMajorId())
                 .majorName(professor.getMajor().getMajorName())
                 .profName(professor.getProfName())
+                .professorAverageGradePoint(professor.getAverageGradePoint())
                 .build();
     }
 }

--- a/src/main/java/com/example/gasip/professor/model/Professor.java
+++ b/src/main/java/com/example/gasip/professor/model/Professor.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Table(name = "prof")
@@ -19,7 +21,7 @@ public class Professor {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Schema(description = "교수 ID")
     private Long profId;
-    @Column(nullable = false,length = 40)
+    @Column(nullable = false, length = 40)
     @Schema(description = "교수 이름")
     private String profName;
     @ManyToOne(fetch = FetchType.LAZY)
@@ -27,11 +29,20 @@ public class Professor {
     @Schema(description = "교수 전공")
     private Major major;
 
+    @Transient
+    private String averageGradePoint;
+
+
     @Builder
-    public Professor(Long profId, String profName,Major major) {
+
+    public Professor(Long profId, String profName, Major major) {
         this.profId = profId;
         this.profName = profName;
         this.major = major;
+    }
+
+    public void updateProfessor(String averagePoint) {
+        this.averageGradePoint = averagePoint;
     }
 
 }

--- a/src/main/java/com/example/gasip/professor/service/ProfessorService.java
+++ b/src/main/java/com/example/gasip/professor/service/ProfessorService.java
@@ -1,5 +1,7 @@
 package com.example.gasip.professor.service;
 
+import com.example.gasip.board.model.Board;
+import com.example.gasip.board.repository.BoardRepository;
 import com.example.gasip.major.model.Major;
 import com.example.gasip.professor.dto.ProfessorResponse;
 import com.example.gasip.professor.model.Professor;
@@ -8,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,6 +18,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ProfessorService {
     private final ProfessorRepository professorRepository;
+    private final BoardRepository boardRepository;
 
     /**
      * 교수 조회
@@ -35,6 +39,16 @@ public class ProfessorService {
     public ProfessorResponse findByProfId(Long profId) {
         Professor professor = professorRepository.findById(profId)
                 .orElseThrow(IllegalArgumentException::new);
+        List<Board> boardList = boardRepository.findAllByProfessor(professor);
+        Double professorAverageGradePoint = 0.0;
+        int count = 0;
+        for (Board board : boardList) {
+            if (board.getGradePoint() != 0) {
+                professorAverageGradePoint += board.getGradePoint();
+                count += 1;
+            }
+        }
+        professor.updateProfessor(String.valueOf(professorAverageGradePoint/count));
         return ProfessorResponse.fromEntity(professor);
     }
 


### PR DESCRIPTION
## 작업 요약
- 평점이 0인 Board는 카운트 제외
- 교수 정보 불러오는 로직과 함께 전달
- 교수 엔티티에 @Transient 어노테이션 활용하여 DB에 평균 평점 칼럼 저장X

## Issue Link
#134 

## 문제점 및 어려움
평균 평점 계산 시 시간 복잡도 O(N) 으로 진행
Board가 많아지면 시간 소요가 많을 것으로 예상

## 해결 방안
흠..

## Reference
