### PR TITLE
Refactor : 전체 글에서 인기글 조회하는 로직으로 변경

### DIFF
--- a/src/main/java/com/example/gasip/board/controller/BoardController.java
+++ b/src/main/java/com/example/gasip/board/controller/BoardController.java
@@ -88,13 +88,12 @@ public class BoardController {
             );
     }
 
-    @GetMapping("/best/{profId}")
-    public ResponseEntity<?> getBestBoard(@PathVariable Long profId,
-    Pageable pageable) {
+    @GetMapping("/best")
+    public ResponseEntity<?> getBestBoard(Pageable pageable) {
         return ResponseEntity
             .ok()
             .body(
-                ApiUtils.success(boardService.findBestBoard(profId,pageable))
+                ApiUtils.success(boardService.findBestBoard(pageable))
             );
     }
 

--- a/src/main/java/com/example/gasip/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/gasip/board/repository/BoardRepository.java
@@ -12,9 +12,7 @@ import java.util.List;
 @Repository
 public interface BoardRepository extends JpaRepository<Board,Long>,BoardRepositoryCustom {
     Page<Board> findAllByOrderByRegDateDesc(Pageable pageable);
-    Page<Board> findByProfessorOrderByLikeCountDescClickCountDesc(Professor professor, Pageable pageable);
-    List<Board> findAllByProfessor(Professor professor);
-
+    Page<Board> findByOrderByLikeCountDescClickCountDesc(Pageable pageable);
     // 게시글 내용 검색
     Page<Board> findByContentContaining(String content, Pageable pageable);
 }

--- a/src/main/java/com/example/gasip/board/service/BoardService.java
+++ b/src/main/java/com/example/gasip/board/service/BoardService.java
@@ -68,9 +68,9 @@ public class BoardService {
         return boardId + "번 게시글이 삭제되었습니다.";
     }
     @Transactional
-    public List<BoardReadResponse> findBestBoard(Long profId, Pageable pageable) {
-        Professor professor = professorRepository.getReferenceById(profId);
-        return boardRepository.findByProfessorOrderByLikeCountDescClickCountDesc(professor, pageable)
+    public List<BoardReadResponse> findBestBoard(Pageable pageable) {
+
+        return boardRepository.findByOrderByLikeCountDescClickCountDesc(pageable)
             .stream()
             .map(BoardReadResponse::fromEntity)
             .collect(Collectors.toList());


### PR DESCRIPTION
## 작업 요약
- 교수별 인기글 조회에서 전체 인기글 조회로 변경

## Issue Link
#136 

## 문제점 및 어려움
- 전체 게시글에서 좋아요 몇개부터 인기글로 분류할지 기준 필요
## 해결 방안
- 회의 후 확정
## Reference
