### PR TITLE
Refactor : 게시글 조회 시 회원 정보를 고려하여 조회하도록 로직 완성

### DIFF
--- a/src/main/java/com/example/gasip/board/controller/BoardController.java
+++ b/src/main/java/com/example/gasip/board/controller/BoardController.java
@@ -65,8 +65,7 @@ public class BoardController {
         return ResponseEntity
             .ok()
             .body(
-                ApiUtils.success(boardService.findBoardIdWithOutMember(postId))
-//                ApiUtils.success(boardService.findBoardId(postId,memberDetails))
+                ApiUtils.success(boardService.findBoardId(postId,memberDetails))
 
             );
     }

--- a/src/main/java/com/example/gasip/board/service/BoardService.java
+++ b/src/main/java/com/example/gasip/board/service/BoardService.java
@@ -53,14 +53,10 @@ public class BoardService {
 
     @Transactional
     public BoardReadResponse findBoardId(Long postId,MemberDetails memberDetails) {
-        Member member = memberRepository.findById(memberDetails.getId()).orElseThrow(() -> new MemberNotFoundException(ErrorCode.NOT_FOUND_MEMBER));
-        insertView(postId,member);
-        Board board = boardRepository.findById(postId).orElseThrow(() -> new BoardNotFoundException(ErrorCode.NOT_FOUND_BOARD));
+        Member member = memberRepository.findById(memberDetails.getId()).orElseThrow(
+            () -> new MemberNotFoundException(ErrorCode.NOT_FOUND_MEMBER));
+        Board board = insertView(postId, member);
         return BoardReadResponse.fromEntity(board);
-    }
-    @Transactional
-    public BoardReadResponse findBoardIdWithOutMember(Long boardId) {
-        return addViewWithoutMember(boardId);
     }
     @Transactional
     public BoardUpdateResponse editBoard(MemberDetails memberDetails,Long boardId,BoardUpdateRequest boardUpdateRequest) {
@@ -89,13 +85,13 @@ public class BoardService {
         return board;
     }
     @Transactional
-    public void insertView(Long postId,Member member) {
+    public Board insertView(Long postId,Member member) {
         String viewCount = redisViewCountService.getData(String.valueOf(member.getMemberId()));
         Board board = boardRepository.findById(postId)
-            .orElseThrow(() -> new NotFoundException("Could not found board id : " + postId));
+            .orElseThrow(() -> new BoardNotFoundException(ErrorCode.NOT_FOUND_BOARD));
         if (viewCount == null) {
             redisViewCountService.setDateExpire(String.valueOf(member.getMemberId()), postId + "_", calculateTimeOut(5));
-            boardRepository.addViewCount(board);
+            redisViewCountService.addViewCountInRedis(postId);
         } else {
             String[] strArray = viewCount.split("_");
             List<String> redisBoardList = Arrays.asList(strArray);
@@ -108,13 +104,15 @@ public class BoardService {
                         break;
                     }
                 }
+                // 근데 없다면,사용자Id를 key로 가지는 곳에 게시글Id를 추가함 + 게시글 조회수 +1
                 if (!isview) {
-                    viewCount += postId + "_";
-                    redisViewCountService.setDateExpire(String.valueOf(member.getMemberId()),viewCount,calculateTimeOut(5));
-                    boardRepository.addViewCount(board);
+                    String alreadyView = postId + "_";
+                    redisViewCountService.addBoardId(String.valueOf(member.getMemberId()),alreadyView);
+                    redisViewCountService.addViewCountInRedis(postId);
                 }
             }
         }
+        return board;
     }
     public static long calculateTimeOut(int time) {
         LocalDateTime now = LocalDateTime.now();
@@ -122,12 +120,6 @@ public class BoardService {
         return ChronoUnit.SECONDS.between(now, midnight);
     }
 
-    @Transactional
-    public BoardReadResponse addViewWithoutMember(Long boardId) {
-        Board board = boardRepository.getReferenceById(boardId);
-        redisViewCountService.addViewCountInRedis(boardId);
-        return BoardReadResponse.fromEntity(board);
-    }
 
     @Scheduled(cron = "0 * * * * *",zone = "Asia/Seoul")
     @Transactional

--- a/src/main/java/com/example/gasip/board/service/RedisViewCountService.java
+++ b/src/main/java/com/example/gasip/board/service/RedisViewCountService.java
@@ -25,17 +25,21 @@ public class RedisViewCountService {
         Duration expireDuration = Duration.ofSeconds(duration);
         valueOperations.set(key, value, expireDuration);
     }
+    public void addBoardId(String key, String value) {
+        ValueOperations<String,String> valueOperations = stringRedisTemplate.opsForValue();
+        valueOperations.append(key, value);
+    }
 
     public void addViewCountInRedis(Long boardId) {
-        String key = String.valueOf(boardId);
+        String key = String.valueOf(boardId)+"board";
         ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
         SetOperations<String, String> setOperations = stringRedisTemplate.opsForSet();
         if (getData(key) == null) {
             valueOperations.set(key,"0");
-            setOperations.add("keyList", key);
+            setOperations.add("keyList", key.replace("board",""));
         }
         if (!setOperations.isMember("keyList",getData(key))) {
-            setOperations.add("keyList",key);
+            setOperations.add("keyList",key.replace("board",""));
         }
         valueOperations.increment(key);
     }
@@ -48,6 +52,6 @@ public class RedisViewCountService {
 
     public String getAndDeleteData(String key) {
         ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
-        return valueOperations.getAndDelete(key);
+        return valueOperations.getAndDelete(key+"board");
     }
 }


### PR DESCRIPTION
## 작업 요약
- redis 저장 key 이름 변경(boardId -> boardId +"board")
- 서비스 단 안쓰는 로직 삭제
- Redis에 값 추가하는 로직 생성
## Issue Link
#237 
## 문제점 및 어려움
- 조회수 중복 방지 로직 중, redis에 저장할 때 TTL을 5분으로 설정.
- 1개의 key값에 value를 계속 추가하는 방식이다보니, TTL로 설정한 시간은 줄어드는 와중에 새로운 값이 추가.
- 이렇게 된다면 예를 들어 TTL이 15초 남았는데 새로운 게시글 ID가 들어오게 되면 15초 이후엔 redis가 초기화되어 다시 조회할 수 있게 되는 허점 발생
## 해결 방안
- 추후 더 좋은 방식이 있다면 리팩토링 진행
## Reference
https://hyem5019.tistory.com/entry/Gasip-%EA%B2%8C%EC%8B%9C%EA%B8%80-%EC%A1%B0%ED%9A%8C%EC%88%98-%EC%A4%91%EB%B3%B5-%EB%B0%A9%EC%A7%80-%EC%B2%98%EB%A6%AC-%EB%A1%9C%EC%A7%81-%EA%B5%AC%ED%98%84