### PR TITLE
Feature/#246 professor refactor

### DIFF
--- a/src/main/java/com/example/gasip/board/controller/BoardController.java
+++ b/src/main/java/com/example/gasip/board/controller/BoardController.java
@@ -155,7 +155,7 @@ public class BoardController {
      * 교수 정보 및 게시글 불러오기
      */
     @GetMapping("/boards-detail/{profId}")
-    public ResponseEntity<?> findBoarByProfessor(@PathVariable Long profId, Pageable pageable) {
+    public ResponseEntity<?> findçiBoarByProfessor(@PathVariable Long profId, Pageable pageable) {
         return ResponseEntity
                 .ok()
                 .body(

--- a/src/main/java/com/example/gasip/board/controller/BoardController.java
+++ b/src/main/java/com/example/gasip/board/controller/BoardController.java
@@ -5,6 +5,7 @@ import com.example.gasip.board.dto.BoardUpdateRequest;
 import com.example.gasip.board.service.BoardService;
 import com.example.gasip.global.api.ApiUtils;
 import com.example.gasip.global.security.MemberDetails;
+import com.example.gasip.professor.service.ProfessorService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class BoardController {
     private final BoardService boardService;
+    private final ProfessorService professorService;
 
     @GetMapping("/all-boards")
     @Operation(summary = "전체 게시글 정보 요청", description = "모든 게시글 목록을 불러옵니다.", tags = {"Board Controller"})
@@ -148,6 +150,18 @@ public class BoardController {
                         ApiUtils.success(
                                 boardService.findByProfNameLike(profName)
                         )
+                );
+    }
+
+    /**
+     * 교수 정보 및 게시글 불러오기
+     */
+    @GetMapping("/test/{profId}")
+    public ResponseEntity<?> findBoarByProfessor(@PathVariable Long profId, Pageable pageable) {
+        return ResponseEntity
+                .ok()
+                .body(
+                        ApiUtils.success(boardService.findBoarByProfessor(profId, pageable))
                 );
     }
 }

--- a/src/main/java/com/example/gasip/board/controller/BoardController.java
+++ b/src/main/java/com/example/gasip/board/controller/BoardController.java
@@ -5,7 +5,6 @@ import com.example.gasip.board.dto.BoardUpdateRequest;
 import com.example.gasip.board.service.BoardService;
 import com.example.gasip.global.api.ApiUtils;
 import com.example.gasip.global.security.MemberDetails;
-import com.example.gasip.professor.service.ProfessorService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class BoardController {
     private final BoardService boardService;
-    private final ProfessorService professorService;
 
     @GetMapping("/all-boards")
     @Operation(summary = "전체 게시글 정보 요청", description = "모든 게시글 목록을 불러옵니다.", tags = {"Board Controller"})
@@ -156,7 +154,7 @@ public class BoardController {
     /**
      * 교수 정보 및 게시글 불러오기
      */
-    @GetMapping("/test/{profId}")
+    @GetMapping("/boards-detail/{profId}")
     public ResponseEntity<?> findBoarByProfessor(@PathVariable Long profId, Pageable pageable) {
         return ResponseEntity
                 .ok()

--- a/src/main/java/com/example/gasip/board/dto/BoardProfessorReadResponse.java
+++ b/src/main/java/com/example/gasip/board/dto/BoardProfessorReadResponse.java
@@ -1,0 +1,69 @@
+package com.example.gasip.board.dto;
+
+import com.example.gasip.board.model.Board;
+import com.example.gasip.global.entity.BaseTimeEntity;
+import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@SuperBuilder
+@Schema(description = "게시글 읽기 Response DTO 관련 VO")
+@AllArgsConstructor
+public class BoardProfessorReadResponse extends BaseTimeEntity {
+    @NotNull
+    @Schema(description = "게시글 ID")
+    private Long postId;
+    @NotNull
+    @Schema(description = "게시글 내용")
+    private String content;
+    @Schema(description = "게시글 조회수")
+    private Long clickCount;
+    @Schema(description = "게시글 좋아요")
+    private Long likeCount;
+    @Schema(description = "교수 평점")
+    private int gradePoint;
+
+    @NotNull
+    @Schema(description = "게시글과 관련된 교수 정보")
+    private Long profId;
+    private String profName;
+    private Long majorId;
+    private String majorName;
+
+    @QueryProjection
+    public BoardProfessorReadResponse(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Long clickCount, Long likeCount, int gradePoint, Long profId, String profName, Long majorId, String majorName) {
+        super(regDate, updateDate);
+        this.postId = postId;
+        this.content = content;
+        this.clickCount = clickCount;
+        this.likeCount = likeCount;
+        this.gradePoint = gradePoint;
+        this.profId = profId;
+        this.profName = profName;
+        this.majorId = majorId;
+        this.majorName = majorName;
+    }
+    public static BoardProfessorReadResponse fromEntity(Board board) {
+        return BoardProfessorReadResponse.builder()
+                .regDate(board.getRegDate())
+                .updateDate(board.getUpdateDate())
+                .postId(board.getPostId())
+                .content(board.getContent())
+                .clickCount(board.getClickCount())
+                .likeCount(board.getLikeCount())
+                .gradePoint(board.getGradePoint())
+                .profId(board.getProfessor().getProfId())
+                .profName(board.getProfessor().getProfName())
+                .majorId(board.getProfessor().getCategory().getId())
+                .majorName(board.getProfessor().getCategory().getMajorName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/gasip/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/gasip/board/repository/BoardRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface BoardRepository extends JpaRepository<Board,Long>,BoardRepositoryCustom {
     Page<Board> findAllByOrderByRegDateDesc(Pageable pageable);
@@ -15,4 +17,6 @@ public interface BoardRepository extends JpaRepository<Board,Long>,BoardReposito
     Page<Board> findByContentContainingOrderByRegDateDesc(String content, Pageable pageable);
 
     Page<Board> findAllByProfessorOrderByRegDateDesc(Professor professor, Pageable pageable);
+
+    List<Board> findBoardByProfessor(Professor Professor);
 }

--- a/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustom.java
@@ -1,10 +1,10 @@
 package com.example.gasip.board.repository;
 
 import com.example.gasip.board.dto.BoardContentDto;
+import com.example.gasip.board.dto.BoardProfessorReadResponse;
 import com.example.gasip.board.dto.BoardReadRequest;
 import com.example.gasip.board.dto.BoardReadResponse;
 import com.example.gasip.board.model.Board;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -25,4 +25,9 @@ public interface BoardRepositoryCustom {
     List<BoardReadResponse> findByProfNameLike(String profName);
 
     List<BoardReadResponse> findBestBoard(Pageable pageable);
+
+    /**
+     * 교수 상세정보 넘기기
+     */
+    List<BoardProfessorReadResponse> findBoarByProfessor(Long profId);
 }

--- a/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustomImpl.java
@@ -1,9 +1,6 @@
 package com.example.gasip.board.repository;
 
-import com.example.gasip.board.dto.BoardContentDto;
-import com.example.gasip.board.dto.BoardReadRequest;
-import com.example.gasip.board.dto.BoardReadResponse;
-import com.example.gasip.board.dto.QBoardReadResponse;
+import com.example.gasip.board.dto.*;
 import com.example.gasip.board.model.Board;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -51,6 +48,21 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
                 .from(board)
                 .leftJoin(board.professor, professor)
                 .where(board.professor.profName.like(profName))
+                .orderBy(board.regDate.desc())
+                .fetch();
+    }
+
+    /**
+     * 교수 게시글 정보 넘겨주기
+     */
+    @Override
+    public List<BoardProfessorReadResponse> findBoarByProfessor(Long profId) {
+        return queryFactory
+                .select(new QBoardProfessorReadResponse(
+                        board.regDate, board.updateDate, board.postId, board.content, board.clickCount, board.likeCount, board.gradePoint, board.professor.profId, board.professor.profName, board.professor.category.Id, board.professor.category.majorName))
+                .from(board)
+                .leftJoin(board.professor, professor)
+                .where(board.professor.profId.eq(profId))
                 .orderBy(board.regDate.desc())
                 .fetch();
     }

--- a/src/main/java/com/example/gasip/board/service/BoardService.java
+++ b/src/main/java/com/example/gasip/board/service/BoardService.java
@@ -14,12 +14,12 @@ import com.example.gasip.member.model.Member;
 import com.example.gasip.member.repository.MemberRepository;
 import com.example.gasip.professor.model.Professor;
 import com.example.gasip.professor.repository.ProfessorRepository;
+import com.example.gasip.professor.service.ProfessorService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.webjars.NotFoundException;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -35,6 +35,8 @@ public class BoardService {
     private final MemberRepository memberRepository;
     private final ProfessorRepository professorRepository;
     private final RedisViewCountService redisViewCountService;
+
+    private final ProfessorService professorService;
 
     @Transactional
     public List<BoardReadResponse> findAllByOrderByRegDateDesc(Pageable pageable) {
@@ -59,6 +61,7 @@ public class BoardService {
             .collect(Collectors.toList());
     }
 
+
     @Transactional
     public BoardReadResponse findBoardId(Long postId,MemberDetails memberDetails) {
         Member member = memberRepository.findById(memberDetails.getId()).orElseThrow(
@@ -67,7 +70,7 @@ public class BoardService {
         return BoardReadResponse.fromEntity(board);
     }
     @Transactional
-    public BoardUpdateResponse editBoard(MemberDetails memberDetails,Long boardId,BoardUpdateRequest boardUpdateRequest) {
+    public BoardUpdateResponse editBoard(MemberDetails memberDetails, Long boardId, BoardUpdateRequest boardUpdateRequest) {
         Board board = validatedBoardWritter(memberDetails, boardId);
         board.updateBoard(boardUpdateRequest.getContent());
         return BoardUpdateResponse.fromEntity(board);
@@ -156,6 +159,15 @@ public class BoardService {
     @Transactional
     public List<BoardReadResponse> findByProfNameLike(String profName) {
         return boardRepository.findByProfNameLike(profName);
+    }
+
+    /**
+     *
+     */
+    @Transactional
+    public List<BoardProfessorReadResponse>  findBoarByProfessor(Long profId, Pageable pageable) {
+        Professor professor = professorRepository.findById(profId).orElseThrow(IllegalArgumentException::new);
+        return boardRepository.findBoarByProfessor(profId);
     }
 
 }

--- a/src/main/java/com/example/gasip/board/service/BoardService.java
+++ b/src/main/java/com/example/gasip/board/service/BoardService.java
@@ -14,7 +14,6 @@ import com.example.gasip.member.model.Member;
 import com.example.gasip.member.repository.MemberRepository;
 import com.example.gasip.professor.model.Professor;
 import com.example.gasip.professor.repository.ProfessorRepository;
-import com.example.gasip.professor.service.ProfessorService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -35,8 +34,6 @@ public class BoardService {
     private final MemberRepository memberRepository;
     private final ProfessorRepository professorRepository;
     private final RedisViewCountService redisViewCountService;
-
-    private final ProfessorService professorService;
 
     @Transactional
     public List<BoardReadResponse> findAllByOrderByRegDateDesc(Pageable pageable) {
@@ -166,7 +163,6 @@ public class BoardService {
      */
     @Transactional
     public List<BoardProfessorReadResponse>  findBoarByProfessor(Long profId, Pageable pageable) {
-        Professor professor = professorRepository.findById(profId).orElseThrow(IllegalArgumentException::new);
         return boardRepository.findBoarByProfessor(profId);
     }
 

--- a/src/main/java/com/example/gasip/professor/controller/ProfessorController.java
+++ b/src/main/java/com/example/gasip/professor/controller/ProfessorController.java
@@ -1,5 +1,6 @@
 package com.example.gasip.professor.controller;
 
+import com.example.gasip.board.service.BoardService;
 import com.example.gasip.category.model.Category;
 import com.example.gasip.global.api.ApiUtils;
 import com.example.gasip.professor.dto.ProfessorResponse;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProfessorController {
 
     private final ProfessorService professorService;
+    private final BoardService boardService;
 
     /**
      * 교수 조회
@@ -54,6 +56,7 @@ public class ProfessorController {
             .body(
                 ApiUtils.success(
                     professorService.findByProfId(profId)
+
                 )
             );
     }
@@ -88,5 +91,17 @@ public class ProfessorController {
                         )
                 );
     }
+
+//    /**
+//     * 교수 정보 및 게시글 불러오기
+//     */
+//    @GetMapping("/board/{profId}")
+//    public ResponseEntity<?> findBoarByProfessor(@PathVariable Long profId, Pageable pageable) {
+//        return ResponseEntity
+//                .ok()
+//                .body(
+//                        ApiUtils.success(professorService.findBoarByProfessor(profId, pageable))
+//                );
+//    }
 
 }

--- a/src/main/java/com/example/gasip/professor/controller/ProfessorController.java
+++ b/src/main/java/com/example/gasip/professor/controller/ProfessorController.java
@@ -1,6 +1,5 @@
 package com.example.gasip.professor.controller;
 
-import com.example.gasip.board.service.BoardService;
 import com.example.gasip.category.model.Category;
 import com.example.gasip.global.api.ApiUtils;
 import com.example.gasip.professor.dto.ProfessorResponse;
@@ -11,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProfessorController {
 
     private final ProfessorService professorService;
-    private final BoardService boardService;
 
     /**
      * 교수 조회
@@ -50,7 +49,7 @@ public class ProfessorController {
      */
     @GetMapping("{profId}")
     @Operation(summary = "교수 상세 정보 불러오기", description = "교수 상세 정보를 불러옵니다.", tags = { "Professor Controller" })
-    public ResponseEntity<?> findByProfId(@PathVariable Long profId) {
+    public ResponseEntity<?> findByProfId(@PathVariable Long profId, Pageable pageable) {
         return ResponseEntity
             .ok()
             .body(
@@ -92,16 +91,16 @@ public class ProfessorController {
                 );
     }
 
-//    /**
-//     * 교수 정보 및 게시글 불러오기
-//     */
-//    @GetMapping("/board/{profId}")
-//    public ResponseEntity<?> findBoarByProfessor(@PathVariable Long profId, Pageable pageable) {
-//        return ResponseEntity
-//                .ok()
-//                .body(
-//                        ApiUtils.success(professorService.findBoarByProfessor(profId, pageable))
-//                );
-//    }
+    /**
+     * 교수 정보 및 게시글 불러오기
+     */
+    @GetMapping("/boards-detail/{profId}")
+    public ResponseEntity<?> findBoardByProfessor(@PathVariable Long profId) {
+        return ResponseEntity
+                .ok()
+                .body(
+                        ApiUtils.success(professorService.findBoardByProfessor(profId))
+                );
+    }
 
 }

--- a/src/main/java/com/example/gasip/professor/dto/ProfessorWithBoardResponse.java
+++ b/src/main/java/com/example/gasip/professor/dto/ProfessorWithBoardResponse.java
@@ -1,0 +1,49 @@
+package com.example.gasip.professor.dto;
+
+import com.example.gasip.board.model.Board;
+import com.example.gasip.professor.model.Professor;
+import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class ProfessorWithBoardResponse {
+    @Schema(description = "교수 ID")
+    private Long profId;
+    @Schema(description = "교수 이름")
+    private String profName;
+    @Schema(description = "교수 전공 ID")
+    private Long majorId;
+    @Schema(description = "교수 전공 이름")
+    private String majorName;
+    @Schema(description = "교수 평균 평점")
+    private String professorAverageGradePoint;
+
+    private String content;
+    private Long postId;
+
+    @QueryProjection
+    public ProfessorWithBoardResponse(Long profId, String profName, Long majorId, String majorName, String content, Long postId) {
+        this.profId = profId;
+        this.profName = profName;
+        this.majorId = majorId;
+        this.majorName = majorName;
+        this.content = content;
+        this.postId = postId;
+    }
+
+
+    public static ProfessorWithBoardResponse fromEntity(Professor professor, Board board) {
+        return ProfessorWithBoardResponse.builder()
+                .profId(professor.getProfId())
+                .profName(professor.getProfName())
+                .majorId(professor.getCategory().getId())
+                .majorName(professor.getCategory().getMajorName())
+                .professorAverageGradePoint(professor.getAverageGradePoint())
+                .content(board.getContent())
+                .postId(board.getPostId())
+                .build();
+    }
+}

--- a/src/main/java/com/example/gasip/professor/repository/ProfessorRepository.java
+++ b/src/main/java/com/example/gasip/professor/repository/ProfessorRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProfessorRepository extends JpaRepository<Professor, Long> {
+public interface ProfessorRepository extends JpaRepository<Professor, Long>, ProfessorRepositoryCustom {
     List<Professor> findProfessorByCategory(Category Id);
 
     List<Professor> findProfessorByProfNameLike(String profName);

--- a/src/main/java/com/example/gasip/professor/repository/ProfessorRepositoryCustom.java
+++ b/src/main/java/com/example/gasip/professor/repository/ProfessorRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.gasip.professor.repository;
+
+import com.example.gasip.professor.dto.ProfessorWithBoardResponse;
+
+import java.util.List;
+
+public interface ProfessorRepositoryCustom {
+    List<ProfessorWithBoardResponse> findBoardByProfessor(Long profId);
+}
+

--- a/src/main/java/com/example/gasip/professor/repository/ProfessorRepositoryCustomImpl.java
+++ b/src/main/java/com/example/gasip/professor/repository/ProfessorRepositoryCustomImpl.java
@@ -1,0 +1,26 @@
+package com.example.gasip.professor.repository;
+
+import com.example.gasip.professor.dto.ProfessorWithBoardResponse;
+import com.example.gasip.professor.dto.QProfessorWithBoardResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.example.gasip.board.model.QBoard.board;
+import static com.example.gasip.professor.model.QProfessor.professor;
+@RequiredArgsConstructor
+public class ProfessorRepositoryCustomImpl implements ProfessorRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ProfessorWithBoardResponse> findBoardByProfessor(Long profId) {
+        return queryFactory
+                .select(new QProfessorWithBoardResponse(
+                        professor.profId, professor.profName, professor.category.Id, professor.category.majorName, board.content, board.postId))
+//                .select(Projections.constructor(ProfessorWithBoardResponse.class, board))
+                .from(professor, board)
+                .where(professor.profId.eq(board.professor.profId), board.professor.profId.eq(profId))
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/gasip/professor/service/ProfessorService.java
+++ b/src/main/java/com/example/gasip/professor/service/ProfessorService.java
@@ -4,6 +4,7 @@ import com.example.gasip.board.repository.BoardRepository;
 import com.example.gasip.category.model.Category;
 import com.example.gasip.grade.repository.GradeRepository;
 import com.example.gasip.professor.dto.ProfessorResponse;
+import com.example.gasip.professor.dto.ProfessorWithBoardResponse;
 import com.example.gasip.professor.model.Professor;
 import com.example.gasip.professor.repository.ProfessorRepository;
 import lombok.RequiredArgsConstructor;
@@ -74,4 +75,13 @@ public class ProfessorService {
 //        Professor professor = professorRepository.findById(profId).orElseThrow(IllegalArgumentException::new);
 //        return boardRepository.findBoarByProfessor(professor);
 //    }
+
+    /**
+     * 교수 상세정보 및 교수 게시글 불러오기
+     */
+    @Transactional
+    public List<ProfessorWithBoardResponse> findBoardByProfessor(Long profId) {
+        return professorRepository.findBoardByProfessor(profId);
+    }
+
 }

--- a/src/main/java/com/example/gasip/professor/service/ProfessorService.java
+++ b/src/main/java/com/example/gasip/professor/service/ProfessorService.java
@@ -1,5 +1,6 @@
 package com.example.gasip.professor.service;
 
+import com.example.gasip.board.repository.BoardRepository;
 import com.example.gasip.category.model.Category;
 import com.example.gasip.grade.repository.GradeRepository;
 import com.example.gasip.professor.dto.ProfessorResponse;
@@ -17,6 +18,7 @@ import java.util.stream.Collectors;
 public class ProfessorService {
     private final ProfessorRepository professorRepository;
     private final GradeRepository gradeRepository;
+    private final BoardRepository boardRepository;
 
     /**
      * 교수 조회
@@ -63,4 +65,13 @@ public class ProfessorService {
                 .map(ProfessorResponse::fromEntity)
                 .collect(Collectors.toList());
     }
+
+//    /**
+//     *
+//     */
+//    @Transactional
+//    public List<BoardProfessorReadResponse> findBoarByProfessor(Long profId, Pageable pageable) {
+//        Professor professor = professorRepository.findById(profId).orElseThrow(IllegalArgumentException::new);
+//        return boardRepository.findBoarByProfessor(professor);
+//    }
 }


### PR DESCRIPTION
## 작업 요약
교수 ID정보로 쓰여진 게시글 호출하는 기능 추가

## Issue Link
#246 

## 문제점 및 어려움
- 교수 상세페이지 호출 시 교수 상세 정보와 게시글을 하나의 API로 호출해야 되는지 2개의 API로 분리해야 되는지 
- 하나의 API로 구성한다면 연관관계 매핑은 어떻게 할 지 

## 해결 방안
- 결론적으로 최소 기능단위로 분리하기 위해 2개의 API를 만들어 활용하는것으로 결정

## Reference
