### PR TITLE
Feat : 비로그인 시 비밀번호 변경 로직 추가

### DIFF
--- a/src/main/java/com/example/gasip/member/controller/MemberController.java
+++ b/src/main/java/com/example/gasip/member/controller/MemberController.java
@@ -140,6 +140,22 @@ public class MemberController {
                 )
             );
     }
+    @PutMapping("/passwords/noauth")
+    @Tag(name = "Service Member Interface", description = "로그인 화면에서 비밀번호를 재설정하는 api 입니다.")
+    @Operation(summary = "로그인 전 비밀번호 재설정", description = "비밀번호를 재설정하는 api 입니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK", content = {@Content(mediaType = "application/json")})
+    })
+    public ResponseEntity<?> editPasswordWithoutAuth(
+            @RequestBody MemberResetPasswordRequest memberResetPasswordRequest) {
+        return ResponseEntity
+            .ok()
+            .body(
+                ApiUtils.success(
+                    memberService.resetPassword(memberResetPasswordRequest)
+                )
+            );
+    }
 
     @PutMapping("/nicknames")
     @Tag(name = "Service Member Interface", description = "닉네임을 변경하는 api 입니다.")

--- a/src/main/java/com/example/gasip/member/dto/MemberResetPasswordRequest.java
+++ b/src/main/java/com/example/gasip/member/dto/MemberResetPasswordRequest.java
@@ -1,0 +1,16 @@
+package com.example.gasip.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberResetPasswordRequest {
+    @NotNull
+    private String email;
+    @NotNull
+    private String password;
+}

--- a/src/main/java/com/example/gasip/member/dto/MemberResetPasswordResponse.java
+++ b/src/main/java/com/example/gasip/member/dto/MemberResetPasswordResponse.java
@@ -1,0 +1,21 @@
+package com.example.gasip.member.dto;
+
+import com.example.gasip.member.model.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class MemberResetPasswordResponse {
+    String email;
+    String password;
+
+    public static MemberResetPasswordResponse fromEntity(Member member) {
+        return MemberResetPasswordResponse.builder()
+            .email(member.getEmail())
+            .password(member.getPassword())
+            .build();
+    }
+}

--- a/src/main/java/com/example/gasip/member/service/MemberService.java
+++ b/src/main/java/com/example/gasip/member/service/MemberService.java
@@ -190,12 +190,21 @@ public class MemberService {
         member.encodePassword(passwordEncoder);
         return MemberUpdatePasswordResponse.fromEntity(member);
     }
-
+    @Transactional
     public String withdrawAccount(MemberDetails memberDetails) {
         Member member = memberRepository.findById(memberDetails.getId()).orElseThrow(
             () -> new MemberNotFoundException(ErrorCode.NOT_FOUND_MEMBER)
         );
         memberRepository.delete(member);
         return "회원 탈퇴 성공";
+    }
+    @Transactional
+    public MemberResetPasswordResponse resetPassword(MemberResetPasswordRequest memberResetPasswordRequest) {
+        Member member = memberRepository.findByEmail(memberResetPasswordRequest.getEmail()).orElseThrow(
+            () -> new MemberNotFoundException(ErrorCode.NOT_FOUND_MEMBER)
+        );
+        member.updatePassword(memberResetPasswordRequest.getPassword());
+        member.encodePassword(passwordEncoder);
+        return MemberResetPasswordResponse.fromEntity(member);
     }
 }


### PR DESCRIPTION
## 작업 요약
- 사용자가 로그인 화면에서 비밀번호 변경을 할 수 있는 로직 생성
## Issue Link
#314 
## 문제점 및 어려움
- 악의적으로 api를 호출할 시 비밀번호 변경에 대한 방어체계가 백엔드 측에 없음
## 해결 방안

## Reference
