### PR TITLE
refactor : 힙 메모리 초과 오류 방지를 위한 JVM Heap 크기 제한

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -20,6 +20,6 @@ NOW=$(date +%c)
 
 
 echo "[$NOW] > $JAR_PATH 실행" >> $START_LOG
-nohup java -jar $JAR_PATH --spring.profiles.active=dev > $APP_LOG 2> $ERROR_LOG &
+nohup java -Xms256m -Xmx512m -XX:+UseG1GC -jar $JAR_PATH --spring.profiles.active=dev > $APP_LOG 2> $ERROR_LOG &
 
 echo "[$NOW] > 서비스 PID: $SERVICE_PID" >> $START_LOG


### PR DESCRIPTION
Resolves: #510

## 작업 요약
- 힙 메모리 초과 오류 방지를 위한 JVM Heap 크기 제한
## Issue Link

## 문제점 및 어려움

## 해결 방안

## Reference
